### PR TITLE
(Fix/Warning) Warning in GetCommands()

### DIFF
--- a/src/Individual_XP.cpp
+++ b/src/Individual_XP.cpp
@@ -98,6 +98,7 @@ public:
     Individual_XP_command() : CommandScript("Individual_XP_command") { }
     std::vector<ChatCommand> GetCommands() const override
     {
+        static std::vector<ChatCommand> IndividualXPBaseTable;
         if (IndividualXpEnabled) {
             static std::vector<ChatCommand> IndividualXPCommandTable =
             {
@@ -113,13 +114,14 @@ public:
                 { "Enable", SEC_PLAYER, false, &HandleEnableCommand, "" }
             };
 
-            static std::vector<ChatCommand> IndividualXPBaseTable =
+            IndividualXPBaseTable =
             {
                 { "XP", SEC_PLAYER, false, nullptr, "", IndividualXPCommandTable }
             };
 
             return IndividualXPBaseTable;
         }
+        return IndividualXPBaseTable;
     }
     // View Command
     static bool HandleViewCommand(ChatHandler* handler, char const* args)


### PR DESCRIPTION
Good afternoon, sir. The pull request is not urgent. It simply serves to avoid the Warning that occurs, because apparently, if I do not misunderstand, the function currently, would not be returning any value. The previous message was as follows.

```
[ 98%] Building CXX object src/server/scripts/CMakeFiles/scripts.dir/__/__/__/modules/mod-individual-xp/src/Individual_XP.cpp.o
/home/serverwow/azerothcore/modules/mod-individual-xp/src/Individual_XP.cpp:123:5: warning: control may reach end of non-void function [-Wreturn-type]
    }
    ^
1 warning generated.
```

I testified it in Debian 10 with the last commit of AC.

<a href="https://subefotos.com/ver/?353fd34b0a6b3d8d54001aedb27e95d0o.jpg" target="_blank"><img src="http://thumbs.subefotos.com/353fd34b0a6b3d8d54001aedb27e95d0o.jpg" /></a>

I don't know if there's a better way to really fix that Warning. Thank you and I hope it serves you.