### PR TITLE
feat(cpp): Rate now relative to the worldserver's one + Accept float + refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,25 @@
 # ![logo](https://raw.githubusercontent.com/azerothcore/azerothcore.github.io/master/images/logo-github.png) AzerothCore
 - Latest build status with azerothcore: [![Build Status](https://travis-ci.org/azerothcore/mod-individual-xp.svg?branch=master)](https://travis-ci.org/azerothcore/mod-individual-xp)
 
-# Individual XP Module
+## Individual XP Module
 
-Allows players to _View, Set, or Toggle_ the rate at which they gain experience individually.
+Allows players to _set or view_ the rate at which they gain experience individually.
 
-# How to install
+## How to install
 
 1) clone this module into the modules directory of the main source
 2) apply the provided sql in the character database
 3) re-run cmake
 4) compile.
 
-# Config
-
-There are two variables to configure in the Config:
-1) Max XP Rate
-2) Default XP Rate
-
-The Max XP Rate variable dictates how high a player can set their XP rate. </br>
-While the Default  XP Rate variable dictates what XP rate players start with and the rate will be set to if the user does '.XP Default'
-
-# Player Commands
+## Player Commands
 
 | Command     | Description                                       |
 |-------------|---------------------------------------------------|
-| .XP         | Main Module Command                               |
-| .XP View    | Displays the current XP rate                      |
-| .XP Set #   | Changes the XP rate to the value specified        |
-| .XP Default | Returns the XP rate to the default value          |
-| .XP Disable | Disables all XP gain until user does '.XP Enable' |
-| .XP Enable  | Enables all XP gain if it was disabled            |
+| .xp         | Main Module Command                               |
+| .xp view    | Displays the current XP rate                      |
+| .xp set #   | Changes the XP rate to the value specified        |
 
-# Video Showcase
+## Old Video Showcase
 
 [![Youtube Link](https://i.imgur.com/Jhrdgv6.png)](https://www.youtube.com/watch?v=T6UEX47mPeE)
-
-# Show your appreciation
-
-[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=SBJFTAJKUNEXC)

--- a/conf/Individual-XP.conf.dist
+++ b/conf/Individual-XP.conf.dist
@@ -1,26 +1,15 @@
 [worldserver]
 
 #
-#    IndividualXp.Enabled 
+#    IndividualXp.Enabled
 #        Description: Enable or Disable the IndividualXP Module.
 #        Default:     IndividualXp.Enabled   = 1
 #
 IndividualXp.Enabled = 1
 
 #
-#    IndividualXp.Announce 
+#    IndividualXp.Announce
 #        Description: Announce the IndividualXP Module at logon.
 #        Default:     IndividualXp.Announce   = 1
 #
 IndividualXp.Announce = 1
-
-#
-#    MaxXPRate 
-#        Description: This is the max amount a player can set their xp to.
-#        Default:     Default  = 1
-#    DefaultXPRate
-#        Description: This is the default rate players start with.
-#        Default:     Default  = 1
-#
-MaxXPRate = 10
-DefaultXPRate = 1

--- a/sql/world/command.sql
+++ b/sql/world/command.sql
@@ -1,9 +1,6 @@
 DELETE FROM `command` WHERE name IN ('xp', 'xp set', 'xp view', 'xp default', 'xp enable', 'xp disable');
 
-INSERT INTO `command` (`name`, `security`, `help`) VALUES 
+INSERT INTO `command` (`name`, `security`, `help`) VALUES
 ('xp', 0, 'Syntax: .xp $subcommand\nType .help xp to see a list of subcommands\nor .help xp $subcommand to see info on the subcommand.'),
 ('xp set', 0, 'Syntax: .xp set $rate\nSet your custom XP rate.'),
-('xp view', 0, 'Syntax: .xp view\nView your current XP rate.'),
-('xp default', 0, 'Syntax: .xp default\nSet your custom XP rate to the default value'),
-('xp enable', 0, 'Syntax: .xp enable\nEnable the custom XP rate.'),
-('xp disable', 0, 'Syntax: .xp disable\nDisable the custom XP rate.');
+('xp view', 0, 'Syntax: .xp view\nView your current XP rate.');


### PR DESCRIPTION
## Changes

- Changed it to work based on the worldserver.conf xp-rate, so maximum you can set is dictated by that
- Accepts float instead of integer only
- Changed it so that players who set their XP back to the default rate gets deleted from the database, so that there's no longer data filling the database of players using the default XP rate
- Removed not very useful subcommands  (not sure if good idea though, needs testing before and after)


## Testing

This PR requires TESTING:
- please test without the PR first and see how usable it is and how pratical all the commands are (.xp default etc...)
- please test with this PR and see if the missing commands are needed or not at all

I haven't tested mostly because I don't use this module for now. It's not my work (apart from small things like the readme, the conf, the sql, and keeping the announce function)  it's work done by @malow as written in the commit.


## Updating

If you already have these commands in your DB and you are satisfied with this PR (or if this PR gets merged), then you can remove the useless commands from your DB:

```
xp default
xp enable
xp disable
```