### PR TITLE
fix(core/Message) change SendAreaTriggerMessage for PSendSysMessage

### DIFF
--- a/src/individual_xp.cpp
+++ b/src/individual_xp.cpp
@@ -155,7 +155,7 @@ public:
         }
         else
         {
-            player->GetSession()->SendAreaTriggerMessage(ACORE_STRING_COMMAND_VIEW, player->CustomData.GetDefault<PlayerXpRate>("IndividualXP")->XPRate);
+            ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_VIEW, player->CustomData.GetDefault<PlayerXpRate>("IndividualXP")->XPRate);
         }
         return true;
     }
@@ -191,7 +191,7 @@ public:
         }
 
         player->CustomData.GetDefault<PlayerXpRate>("IndividualXP")->XPRate = rate;
-        player->GetSession()->SendAreaTriggerMessage(ACORE_STRING_COMMAND_SET, rate);
+        ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_SET, rate);
         return true;
     }
 
@@ -249,7 +249,7 @@ public:
             return false;
 
         player->CustomData.GetDefault<PlayerXpRate>("IndividualXP")->XPRate = DefaultRate;
-        player->GetSession()->SendAreaTriggerMessage(ACORE_STRING_COMMAND_DEFAULT, DefaultRate);
+        ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_DEFAULT, DefaultRate);
         return true;
     }
 };


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- When I made the previous pull request, to replace the %s and %u, some messages started to have problems to be displayed. I tried to modify them, but in the end, I thought it would be a good idea to send them in the chat, because there are addons that allow you to copy the text, however, if they are a SendAreaTriggerMessag, you cannot copy them.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- Ingame

![chat](https://github.com/user-attachments/assets/f3c904f6-eba7-4cfe-88f9-6e536adb65da)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. If you test the module without this change, some of the commands, when displaying the message, instead of seeing the values, will appear {}.
2. After applying the change, the messages will no longer appear in the center of the screen, but in the chat. But in addition to that, the {} is no longer visible, instead, the value that should appear is displayed.