### PR TITLE
chore. Allow decimal XP rates

### DIFF
--- a/data/sql/db-characters/base/mod_individual_xp_IndividualXP.sql
+++ b/data/sql/db-characters/base/mod_individual_xp_IndividualXP.sql
@@ -14,7 +14,7 @@
 -- Dumping structure for table acore_characters.individualxp
 CREATE TABLE IF NOT EXISTS `individualxp` (
   `CharacterGUID` int(11) NOT NULL,
-  `XPRate` int(11) NOT NULL DEFAULT '0',
+  `XPRate` float NOT NULL,
   PRIMARY KEY (`CharacterGUID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- The possibility of choosing decimal values, intermediate values, such as 0.1 or 1.5 and such values ​​has been added. Previously, only integer values ​​were allowed.
- In the enable command, we had the condition that checked if the player had disabled the experience wrong, since we are denying it, when in reality, it should not be denied, because it is checking if the player does not have the experience enabled.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-individual-xp/issues/25

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- Ingame

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Now you should be able to choose intermediate values, like 0.1 for example. On an NPC, who has x1 experience and gives you 50 points, at 0.1, he should give you 5. It's not perfect, because the emulator and client use integer values, but it's pretty close.