### PR TITLE
Added GM only setting + ability to execute commands on selected chara…

### DIFF
--- a/conf/individual_xp.conf.dist
+++ b/conf/individual_xp.conf.dist
@@ -61,3 +61,18 @@ IndividualXp.MaxXPRate = 10
 #
 
 IndividualXp.DefaultXPRate = 1
+
+#
+#   IndividualXp.GMLevel
+#
+#   Description: Minimum account security level required to use .xp commands.
+#   Example:
+#       0 (Any player can use the commands)
+#       1 (Moderator and above)
+#       2 (GM and above)
+#       3 (Administrator and above)
+#
+#   Default: 3
+#
+
+IndividualXp.GMLevel = 3

--- a/data/sql/db-world/updates/zmod_individual_xp_2026_06_23_00.sql
+++ b/data/sql/db-world/updates/zmod_individual_xp_2026_06_23_00.sql
@@ -1,0 +1,11 @@
+SET @ENTRY := 100010;
+
+DELETE FROM `acore_string` WHERE `entry` BETWEEN @ENTRY+0 AND @ENTRY+5;
+
+INSERT INTO `acore_string` (`entry`, `content_default`, `locale_koKR`, `locale_frFR`, `locale_deDE`, `locale_zhCN`, `locale_zhTW`, `locale_esES`, `locale_esMX`, `locale_ruRU`) VALUES
+(@ENTRY+0, '[XP] You don''t have permission to use XP commands.', '', '', '', '', '', '[XP] No tienes permiso para usar comandos de XP.', '[XP] No tienes permiso para usar comandos de XP.', ''),
+(@ENTRY+1, '[XP] You have set {}''s XP rate to {}.', '', '', '', '', '', '[XP] Has establecido la tasa de XP de {} a {}.', '[XP] Has establecido la tasa de XP de {} a {}.', ''),
+(@ENTRY+2, '[XP] {}''s current XP rate is {}.', '', '', '', '', '', '[XP] La tasa de XP actual de {} es {}.', '[XP] La tasa de XP actual de {} es {}.', ''),
+(@ENTRY+3, '[XP] You have disabled XP gain for {}.', '', '', '', '', '', '[XP] Has desactivado la ganancia de XP para {}.', '[XP] Has desactivado la ganancia de XP para {}.', ''),
+(@ENTRY+4, '[XP] You have enabled XP gain for {}.', '', '', '', '', '', '[XP] Has activado la ganancia de XP para {}.', '[XP] Has activado la ganancia de XP para {}.', ''),
+(@ENTRY+5, '[XP] You have reset {}''s XP rate to the default value of {}.', '', '', '', '', '', '[XP] Has restablecido la tasa de XP de {} al valor predeterminado de {}.', '[XP] Has restablecido la tasa de XP de {} al valor predeterminado de {}.', '');

--- a/data/sql/db-world/updates/zmod_individual_xp_2026_06_24_00.sql
+++ b/data/sql/db-world/updates/zmod_individual_xp_2026_06_24_00.sql
@@ -3,10 +3,10 @@ SET @ENTRY := 100016;
 DELETE FROM `acore_string` WHERE `entry` BETWEEN @ENTRY+0 AND @ENTRY+0;
 
 INSERT INTO `acore_string` (`entry`, `content_default`, `locale_koKR`, `locale_frFR`, `locale_deDE`, `locale_zhCN`, `locale_zhTW`, `locale_esES`, `locale_esMX`, `locale_ruRU`) VALUES
-(@ENTRY+0, '[XP] Player not found or is offline.', '', '', '', '', '', '[XP] Jugador no encontrado o está desconectado.', '[XP] Jugador no encontrado o está desconectado.', '');
+(@ENTRY+0, '[XP] Character not found or is offline.', '', '', '', '', '', '[XP] Personagem no encontrado o está desconectado.', '[XP] Personagem no encontrado o está desconectado.', '');
 
-UPDATE `command` SET `help` = 'Syntax: .xp set $rate [$playername]\nSet your custom XP rate or another player''s XP rate.' WHERE `name` = 'xp set';
-UPDATE `command` SET `help` = 'Syntax: .xp view [$playername]\nView your current XP rate or another player''s XP rate.' WHERE `name` = 'xp view';
-UPDATE `command` SET `help` = 'Syntax: .xp disable [$playername]\nDisable the custom XP rate for yourself or another player.' WHERE `name` = 'xp disable';
-UPDATE `command` SET `help` = 'Syntax: .xp enable [$playername]\nEnable the custom XP rate for yourself or another player.' WHERE `name` = 'xp enable';
-UPDATE `command` SET `help` = 'Syntax: .xp default [$playername]\nSet your custom XP rate or another player''s XP rate to the default value.' WHERE `name` = 'xp default';
+UPDATE `command` SET `help` = 'Syntax: .xp set $rate [$charactername]\nSet your custom XP rate or another character''s XP rate.' WHERE `name` = 'xp set';
+UPDATE `command` SET `help` = 'Syntax: .xp view [$charactername]\nView your current XP rate or another character''s XP rate.' WHERE `name` = 'xp view';
+UPDATE `command` SET `help` = 'Syntax: .xp disable [$charactername]\nDisable the custom XP rate for yourself or another character.' WHERE `name` = 'xp disable';
+UPDATE `command` SET `help` = 'Syntax: .xp enable [$charactername]\nEnable the custom XP rate for yourself or another character.' WHERE `name` = 'xp enable';
+UPDATE `command` SET `help` = 'Syntax: .xp default [$charactername]\nSet your custom XP rate or another character''s XP rate to the default value.' WHERE `name` = 'xp default';

--- a/data/sql/db-world/updates/zmod_individual_xp_2026_06_24_00.sql
+++ b/data/sql/db-world/updates/zmod_individual_xp_2026_06_24_00.sql
@@ -1,0 +1,12 @@
+SET @ENTRY := 100016;
+
+DELETE FROM `acore_string` WHERE `entry` BETWEEN @ENTRY+0 AND @ENTRY+0;
+
+INSERT INTO `acore_string` (`entry`, `content_default`, `locale_koKR`, `locale_frFR`, `locale_deDE`, `locale_zhCN`, `locale_zhTW`, `locale_esES`, `locale_esMX`, `locale_ruRU`) VALUES
+(@ENTRY+0, '[XP] Player not found or is offline.', '', '', '', '', '', '[XP] Jugador no encontrado o está desconectado.', '[XP] Jugador no encontrado o está desconectado.', '');
+
+UPDATE `command` SET `help` = 'Syntax: .xp set $rate [$playername]\nSet your custom XP rate or another player''s XP rate.' WHERE `name` = 'xp set';
+UPDATE `command` SET `help` = 'Syntax: .xp view [$playername]\nView your current XP rate or another player''s XP rate.' WHERE `name` = 'xp view';
+UPDATE `command` SET `help` = 'Syntax: .xp disable [$playername]\nDisable the custom XP rate for yourself or another player.' WHERE `name` = 'xp disable';
+UPDATE `command` SET `help` = 'Syntax: .xp enable [$playername]\nEnable the custom XP rate for yourself or another player.' WHERE `name` = 'xp enable';
+UPDATE `command` SET `help` = 'Syntax: .xp default [$playername]\nSet your custom XP rate or another player''s XP rate to the default value.' WHERE `name` = 'xp default';

--- a/src/individual_xp.cpp
+++ b/src/individual_xp.cpp
@@ -17,6 +17,7 @@ struct IndividualXpModule
 {
     bool Enabled, AnnounceModule, AnnounceRatesOnLogin;
     float MaxRate, DefaultRate;
+    uint32 GMLevel = 3;
 };
 
 IndividualXpModule individualXp;
@@ -32,7 +33,13 @@ enum IndividualXPAcoreString
     ACORE_STRING_COMMAND_SET,
     ACORE_STRING_COMMAND_DISABLED,
     ACORE_STRING_COMMAND_ENABLED,
-    ACORE_STRING_COMMAND_DEFAULT
+    ACORE_STRING_COMMAND_DEFAULT,
+    ACORE_STRING_INSUFFICIENT_SECURITY,
+    ACORE_STRING_COMMAND_SET_OTHER,
+    ACORE_STRING_COMMAND_VIEW_OTHER,
+    ACORE_STRING_COMMAND_DISABLE_OTHER,
+    ACORE_STRING_COMMAND_ENABLE_OTHER,
+    ACORE_STRING_COMMAND_DEFAULT_OTHER
 };
 
 class IndividualXPConf : public WorldScript
@@ -47,6 +54,7 @@ public:
         individualXp.AnnounceRatesOnLogin = sConfigMgr->GetOption<bool>("IndividualXp.AnnounceRatesOnLogin", true);
         individualXp.MaxRate = sConfigMgr->GetOption<float>("IndividualXp.MaxXPRate", 10.0f);
         individualXp.DefaultRate = sConfigMgr->GetOption<float>("IndividualXp.DefaultXPRate", 1.0f);
+        individualXp.GMLevel = sConfigMgr->GetOption<uint32>("IndividualXp.GMLevel", 3);
     }
 };
 
@@ -154,10 +162,21 @@ public:
             return false;
         }
 
+        if (handler->GetSession()->GetSecurity() < individualXp.GMLevel)
+        {
+            handler->PSendSysMessage(ACORE_STRING_INSUFFICIENT_SECURITY);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
         Player* player = handler->GetSession()->GetPlayer();
 
         if (!player)
             return false;
+
+        Player* target = player->GetSelectedPlayer();
+        if (target)
+            player = target;
 
         if (player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_NO_XP_GAIN))
         {
@@ -165,10 +184,12 @@ public:
             handler->SetSentErrorMessage(true);
             return false;
         }
+
+        if (target)
+            ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_VIEW_OTHER, player->GetName(), player->CustomData.GetDefault<PlayerXpRate>("IndividualXP")->XPRate);
         else
-        {
             ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_VIEW, player->CustomData.GetDefault<PlayerXpRate>("IndividualXP")->XPRate);
-        }
+
         return true;
     }
 
@@ -184,10 +205,21 @@ public:
         if (!rate)
             return false;
 
+        if (handler->GetSession()->GetSecurity() < individualXp.GMLevel)
+        {
+            handler->PSendSysMessage(ACORE_STRING_INSUFFICIENT_SECURITY);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
         Player* player = handler->GetSession()->GetPlayer();
 
         if (!player)
             return false;
+
+        Player* target = player->GetSelectedPlayer();
+        if (target)
+            player = target;
 
         if (player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_NO_XP_GAIN))
         {
@@ -195,26 +227,32 @@ public:
             handler->SetSentErrorMessage(true);
             return false;
         }
-        else
+
+        if (rate > individualXp.MaxRate)
         {
-            if (rate > individualXp.MaxRate)
-            {
-                handler->PSendSysMessage(ACORE_STRING_MAX_RATE, individualXp.MaxRate);
-                handler->SetSentErrorMessage(true);
-                return false;
-            }
-
-            if (rate < 0.1f)
-            {
-                handler->PSendSysMessage(ACORE_STRING_MIN_RATE);
-                handler->SetSentErrorMessage(true);
-                return false;
-            }
-
-            player->CustomData.GetDefault<PlayerXpRate>("IndividualXP")->XPRate = rate;
-            ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_SET, rate);
-            return true;
+            handler->PSendSysMessage(ACORE_STRING_MAX_RATE, individualXp.MaxRate);
+            handler->SetSentErrorMessage(true);
+            return false;
         }
+
+        if (rate < 0.1f)
+        {
+            handler->PSendSysMessage(ACORE_STRING_MIN_RATE);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        player->CustomData.GetDefault<PlayerXpRate>("IndividualXP")->XPRate = rate;
+
+        if (target)
+        {
+            ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_SET_OTHER, target->GetName(), rate);
+            ChatHandler(target->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_SET, rate);
+        }
+        else
+            ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_SET, rate);
+
+        return true;
     }
 
     static bool HandleDisableCommand(ChatHandler* handler)
@@ -226,16 +264,29 @@ public:
             return false;
         }
 
+        if (handler->GetSession()->GetSecurity() < individualXp.GMLevel)
+        {
+            handler->PSendSysMessage(ACORE_STRING_INSUFFICIENT_SECURITY);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
         Player* player = handler->GetSession()->GetPlayer();
 
         if (!player)
             return false;
 
+        Player* target = player->GetSelectedPlayer();
+        if (target)
+            player = target;
+
         if (!player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_NO_XP_GAIN))
         {
-            // Turn Disabled On But Don't Change Value...
             player->SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_NO_XP_GAIN);
-            ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_DISABLED);
+            if (target)
+                ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_DISABLE_OTHER, player->GetName());
+            else
+                ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_DISABLED);
             return true;
         }
         else
@@ -254,15 +305,29 @@ public:
             return true;
         }
 
+        if (handler->GetSession()->GetSecurity() < individualXp.GMLevel)
+        {
+            handler->PSendSysMessage(ACORE_STRING_INSUFFICIENT_SECURITY);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
         Player* player = handler->GetSession()->GetPlayer();
 
         if (!player)
             return false;
 
+        Player* target = player->GetSelectedPlayer();
+        if (target)
+            player = target;
+
         if (player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_NO_XP_GAIN))
         {
             player->RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_NO_XP_GAIN);
-            ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_ENABLED);
+            if (target)
+                ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_ENABLE_OTHER, player->GetName());
+            else
+                ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_ENABLED);
         }
         else
         {
@@ -281,10 +346,21 @@ public:
             return false;
         }
 
+        if (handler->GetSession()->GetSecurity() < individualXp.GMLevel)
+        {
+            handler->PSendSysMessage(ACORE_STRING_INSUFFICIENT_SECURITY);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
         Player* player = handler->GetSession()->GetPlayer();
 
         if (!player)
             return false;
+
+        Player* target = player->GetSelectedPlayer();
+        if (target)
+            player = target;
 
         if (player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_NO_XP_GAIN))
         {
@@ -292,12 +368,15 @@ public:
             handler->SetSentErrorMessage(true);
             return false;
         }
+
+        player->CustomData.GetDefault<PlayerXpRate>("IndividualXP")->XPRate = individualXp.DefaultRate;
+
+        if (target)
+            ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_DEFAULT_OTHER, player->GetName(), individualXp.DefaultRate);
         else
-        {
-            player->CustomData.GetDefault<PlayerXpRate>("IndividualXP")->XPRate = individualXp.DefaultRate;
             ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_DEFAULT, individualXp.DefaultRate);
-            return true;
-        }
+
+        return true;
     }
 };
 

--- a/src/individual_xp.cpp
+++ b/src/individual_xp.cpp
@@ -247,7 +247,8 @@ public:
         if (target)
         {
             ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_SET_OTHER, target->GetName(), rate);
-            ChatHandler(target->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_SET, rate);
+            if (WorldSession* targetSession = target->GetSession())
+               ChatHandler(targetSession).PSendSysMessage(ACORE_STRING_COMMAND_SET, rate);
         }
         else
             ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_SET, rate);

--- a/src/individual_xp.cpp
+++ b/src/individual_xp.cpp
@@ -39,7 +39,8 @@ enum IndividualXPAcoreString
     ACORE_STRING_COMMAND_VIEW_OTHER,
     ACORE_STRING_COMMAND_DISABLE_OTHER,
     ACORE_STRING_COMMAND_ENABLE_OTHER,
-    ACORE_STRING_COMMAND_DEFAULT_OTHER
+    ACORE_STRING_COMMAND_DEFAULT_OTHER,
+    ACORE_STRING_PLAYER_NOT_FOUND
 };
 
 class IndividualXPConf : public WorldScript
@@ -153,7 +154,7 @@ public:
         return IndividualXPBaseTable;
     }
 
-    static bool HandleViewCommand(ChatHandler* handler)
+    static bool HandleViewCommand(ChatHandler* handler, Optional<PlayerIdentifier> playerName)
     {
         if (!individualXp.Enabled)
         {
@@ -174,9 +175,28 @@ public:
         if (!player)
             return false;
 
-        Player* target = player->GetSelectedPlayer();
-        if (target)
-            player = target;
+        bool isOther = false;
+
+        if (playerName)
+        {
+            if (!playerName->IsConnected())
+            {
+                handler->PSendSysMessage(ACORE_STRING_PLAYER_NOT_FOUND);
+                handler->SetSentErrorMessage(true);
+                return false;
+            }
+            player = playerName->GetConnectedPlayer();
+            isOther = true;
+        }
+        else
+        {
+            Player* target = player->GetSelectedPlayer();
+            if (target)
+            {
+                player = target;
+                isOther = true;
+            }
+        }
 
         if (player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_NO_XP_GAIN))
         {
@@ -185,7 +205,7 @@ public:
             return false;
         }
 
-        if (target)
+        if (isOther)
             ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_VIEW_OTHER, player->GetName(), player->CustomData.GetDefault<PlayerXpRate>("IndividualXP")->XPRate);
         else
             ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_VIEW, player->CustomData.GetDefault<PlayerXpRate>("IndividualXP")->XPRate);
@@ -193,7 +213,7 @@ public:
         return true;
     }
 
-    static bool HandleSetCommand(ChatHandler* handler, float rate)
+    static bool HandleSetCommand(ChatHandler* handler, float rate, Optional<PlayerIdentifier> playerName)
     {
         if (!individualXp.Enabled)
         {
@@ -217,9 +237,28 @@ public:
         if (!player)
             return false;
 
-        Player* target = player->GetSelectedPlayer();
-        if (target)
-            player = target;
+        bool isOther = false;
+
+        if (playerName)
+        {
+            if (!playerName->IsConnected())
+            {
+                handler->PSendSysMessage(ACORE_STRING_PLAYER_NOT_FOUND);
+                handler->SetSentErrorMessage(true);
+                return false;
+            }
+            player = playerName->GetConnectedPlayer();
+            isOther = true;
+        }
+        else
+        {
+            Player* target = player->GetSelectedPlayer();
+            if (target)
+            {
+                player = target;
+                isOther = true;
+            }
+        }
 
         if (player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_NO_XP_GAIN))
         {
@@ -244,11 +283,11 @@ public:
 
         player->CustomData.GetDefault<PlayerXpRate>("IndividualXP")->XPRate = rate;
 
-        if (target)
+        if (isOther)
         {
-            ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_SET_OTHER, target->GetName(), rate);
-            if (WorldSession* targetSession = target->GetSession())
-               ChatHandler(targetSession).PSendSysMessage(ACORE_STRING_COMMAND_SET, rate);
+            ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_SET_OTHER, player->GetName(), rate);
+            if (WorldSession* targetSession = player->GetSession())
+                ChatHandler(targetSession).PSendSysMessage(ACORE_STRING_COMMAND_SET, rate);
         }
         else
             ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_SET, rate);
@@ -256,7 +295,7 @@ public:
         return true;
     }
 
-    static bool HandleDisableCommand(ChatHandler* handler)
+    static bool HandleDisableCommand(ChatHandler* handler, Optional<PlayerIdentifier> playerName)
     {
         if (!individualXp.Enabled)
         {
@@ -277,14 +316,33 @@ public:
         if (!player)
             return false;
 
-        Player* target = player->GetSelectedPlayer();
-        if (target)
-            player = target;
+        bool isOther = false;
+
+        if (playerName)
+        {
+            if (!playerName->IsConnected())
+            {
+                handler->PSendSysMessage(ACORE_STRING_PLAYER_NOT_FOUND);
+                handler->SetSentErrorMessage(true);
+                return false;
+            }
+            player = playerName->GetConnectedPlayer();
+            isOther = true;
+        }
+        else
+        {
+            Player* target = player->GetSelectedPlayer();
+            if (target)
+            {
+                player = target;
+                isOther = true;
+            }
+        }
 
         if (!player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_NO_XP_GAIN))
         {
             player->SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_NO_XP_GAIN);
-            if (target)
+            if (isOther)
                 ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_DISABLE_OTHER, player->GetName());
             else
                 ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_DISABLED);
@@ -297,7 +355,7 @@ public:
         }
     }
 
-    static bool HandleEnableCommand(ChatHandler* handler)
+    static bool HandleEnableCommand(ChatHandler* handler, Optional<PlayerIdentifier> playerName)
     {
         if (!individualXp.Enabled)
         {
@@ -318,14 +376,33 @@ public:
         if (!player)
             return false;
 
-        Player* target = player->GetSelectedPlayer();
-        if (target)
-            player = target;
+        bool isOther = false;
+
+        if (playerName)
+        {
+            if (!playerName->IsConnected())
+            {
+                handler->PSendSysMessage(ACORE_STRING_PLAYER_NOT_FOUND);
+                handler->SetSentErrorMessage(true);
+                return false;
+            }
+            player = playerName->GetConnectedPlayer();
+            isOther = true;
+        }
+        else
+        {
+            Player* target = player->GetSelectedPlayer();
+            if (target)
+            {
+                player = target;
+                isOther = true;
+            }
+        }
 
         if (player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_NO_XP_GAIN))
         {
             player->RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_NO_XP_GAIN);
-            if (target)
+            if (isOther)
                 ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_ENABLE_OTHER, player->GetName());
             else
                 ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_ENABLED);
@@ -338,7 +415,7 @@ public:
         return true;
     }
 
-    static bool HandleDefaultCommand(ChatHandler* handler)
+    static bool HandleDefaultCommand(ChatHandler* handler, Optional<PlayerIdentifier> playerName)
     {
         if (!individualXp.Enabled)
         {
@@ -359,9 +436,28 @@ public:
         if (!player)
             return false;
 
-        Player* target = player->GetSelectedPlayer();
-        if (target)
-            player = target;
+        bool isOther = false;
+
+        if (playerName)
+        {
+            if (!playerName->IsConnected())
+            {
+                handler->PSendSysMessage(ACORE_STRING_PLAYER_NOT_FOUND);
+                handler->SetSentErrorMessage(true);
+                return false;
+            }
+            player = playerName->GetConnectedPlayer();
+            isOther = true;
+        }
+        else
+        {
+            Player* target = player->GetSelectedPlayer();
+            if (target)
+            {
+                player = target;
+                isOther = true;
+            }
+        }
 
         if (player->HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_NO_XP_GAIN))
         {
@@ -372,7 +468,7 @@ public:
 
         player->CustomData.GetDefault<PlayerXpRate>("IndividualXP")->XPRate = individualXp.DefaultRate;
 
-        if (target)
+        if (isOther)
             ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_DEFAULT_OTHER, player->GetName(), individualXp.DefaultRate);
         else
             ChatHandler(handler->GetSession()).PSendSysMessage(ACORE_STRING_COMMAND_DEFAULT, individualXp.DefaultRate);


### PR DESCRIPTION
…cters

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Added ability to set GM level to be able to use the module's commands to the config.
- Added ability to execute commands on selected characters


## Tests Performed:
Yes i did test in game.


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go in game
2. Try to use a command without the gm level set in the config
3. fail
4. go to another account with GM level set in the config
5. execute command on another player's character (playerbots also work)
6. succeed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `IndividualXp.GMLevel` (default: 3) to control access to `.xp` commands; commands now block with an insufficient-security message when below the threshold.
  * Updated `.xp` to support targeting another character (by name) with clear “not found/offline” feedback; otherwise it uses the selected player.
  * `.xp` subcommands (`enable`, `disable`, `view`, `set`, `default`) are now callable from the console.
  * Improved behavior and messaging for `default` and `enable`/`disable` around XP-gain restrictions.
* **Documentation**
  * Refreshed in-game `.xp` help to match the caller-vs-other targeting syntax and outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->